### PR TITLE
Add cargo audit check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,19 @@ jobs:
         with:
           toolchain: stable
       - uses: bnjbvr/cargo-machete@main
+  audit:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit
   fmt:
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     needs:
       - fmt
       - deps
+      - audit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,6 +77,7 @@ jobs:
     needs:
       - fmt
       - deps
+      - audit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,6 +103,7 @@ jobs:
     needs:
       - fmt
       - deps
+      - audit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -123,6 +126,7 @@ jobs:
     needs:
       - fmt
       - deps
+      - audit
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- add `cargo audit` job to GitHub Actions CI

## Testing
- `cargo check` *(fails: failed to fetch git dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684016b3d7548326a3b0ae3c10f1984c